### PR TITLE
Fixed a strange java.lang.IllegalArgumentException error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
     }
     signingConfigs {
         release {
-            storeFile file(System.getenv("KEYSTORE"))
+            storeFile System.getenv("KEYSTORE")
             storePassword System.getenv("KEYSTORE_PASSWORD")
             keyAlias System.getenv("KEY_ALIAS")
             keyPassword System.getenv("KEY_PASSWORD")


### PR DESCRIPTION
Strange error when syncing gradle project in Android Studio: 

org.gradle.api.GradleScriptException: A problem occurred evaluating project ':app'.
Caused by: java.lang.IllegalArgumentException: path may not be null or empty string. path='null'

patch seems to have fixed the problem

